### PR TITLE
[feature/cash history entity] 가계 내역 Entity

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -4,7 +4,9 @@ module.exports = {
     es2021: true
   },
   extends: [
-    'standard'
+    'standard',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/backend/src/entities/cash-history.ts
+++ b/backend/src/entities/cash-history.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryColumn, RelationId } from 'typeorm';
+import { CashHistories } from '../enums/cash-history.enum';
 import Category from './category';
 import Payment from './payment';
 import User from './user';
@@ -10,6 +11,12 @@ class CashHistory {
 
   @Column()
   price!: number;
+
+  @Column({
+    type: 'enum',
+    enum: CashHistories
+  })
+  type!: CashHistories;
 
   @ManyToOne(() => User, {
     onDelete: 'CASCADE'

--- a/backend/src/entities/cash-history.ts
+++ b/backend/src/entities/cash-history.ts
@@ -1,0 +1,53 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryColumn, RelationId } from 'typeorm';
+import Category from './category';
+import Payment from './payment';
+import User from './user';
+
+@Entity('cash_history')
+class CashHistory {
+  @PrimaryColumn()
+  id!: number;
+
+  @Column()
+  price!: number;
+
+  @ManyToOne(() => User, {
+    onDelete: 'CASCADE'
+  })
+  @JoinColumn({
+    name: 'user_id'
+  })
+  user!: User;
+
+  @RelationId((cashHistory: CashHistory) => cashHistory.user)
+  userId!: number;
+
+  @ManyToOne(() => Category, {
+    onDelete: 'SET NULL'
+  })
+  @JoinColumn({
+    name: 'category_id'
+  })
+  category!: Category | null;
+
+  @RelationId((cashHistory: CashHistory) => cashHistory.category)
+  categoryId!: number | null;
+
+  @ManyToOne(() => Payment, {
+    onDelete: 'SET NULL'
+  })
+  @JoinColumn({
+    name: 'payment_id'
+  })
+  payment!: Payment | null;
+
+  @RelationId((cashHistory: CashHistory) => cashHistory.payment)
+  paymentId!: number | null;
+
+  @CreateDateColumn({
+    name: 'created_at'
+  })
+  createdAt!: Date;
+}
+
+export default CashHistory;

--- a/backend/src/entities/index.ts
+++ b/backend/src/entities/index.ts
@@ -1,9 +1,13 @@
+import CashHistory from './cash-history';
 import Category from './category';
+import Payment from './payment';
 import User from './user';
 
 const entities = [
   User,
-  Category
+  Category,
+  CashHistory,
+  Payment
 ];
 
 export default entities;

--- a/backend/src/enums/cash-history.enum.ts
+++ b/backend/src/enums/cash-history.enum.ts
@@ -1,0 +1,4 @@
+export enum CashHistories {
+  Income,
+  Expenditure
+}


### PR DESCRIPTION
## :bookmark_tabs: #26 가계 내역 Entity 


## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?

- [x] Coding Convention을 준수했나요?

- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* CashHistory 엔티티 정의
* `entities/index.ts`에 Payment, CashHistory를 추가



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점



- Category, Payment가 삭제되었을 경우 `SET NULL`을 통해 해당 컬럼을 NULL로 변경
- ESLint가 Enum을 지원하지 않아 ESLint를 타입스크립트 확장

