### PR TITLE
[feature/cash history fetch] 가계 내역 조회 및 타입 정의

### DIFF
--- a/frontend/error/http-error.ts
+++ b/frontend/error/http-error.ts
@@ -1,0 +1,17 @@
+class HTTPError {
+  status: number;
+
+  constructor (status: number) {
+    this.status = status;
+  }
+
+  static isHTTPError (status: number): boolean {
+    if (status >= 400) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+export default HTTPError;

--- a/frontend/src/api/cash-history.ts
+++ b/frontend/src/api/cash-history.ts
@@ -1,0 +1,20 @@
+import { CashHistoriesResponse } from '../types/cash-history';
+import { getAccessToken, getRequest } from './request';
+
+class CashHistoryAPI {
+  fetchCashHistories (year: number, month: number): Promise<CashHistoriesResponse> {
+    const token = getAccessToken();
+
+    return getRequest<CashHistoriesResponse>('http://localhost:8080/api/cash-history', {
+      query: {
+        year,
+        month
+      },
+      headers: {
+        Authorization: token
+      }
+    });
+  }
+}
+
+export default new CashHistoryAPI();

--- a/frontend/src/api/request.ts
+++ b/frontend/src/api/request.ts
@@ -1,0 +1,108 @@
+import HTTPError from '../../error/http-error';
+import cookie from '../utils/cookie';
+import { buildURL } from '../utils/path';
+
+type Options = {
+  headers?: { [key: string]: string },
+  query?: { [key: string]: string | number },
+  param?: string | number
+}
+
+type BodyOptions = {
+  body: unknown
+} & Options;
+
+export const getAccessToken = (): string => {
+  const token = cookie.get('accessToken');
+  if (token === undefined) {
+    throw new HTTPError(401);
+  }
+
+  return token;
+};
+
+export const getRequest = async <T>(url: string, options: Options): Promise<T> => {
+  const { headers, query, param } = options;
+
+  const requestURL = buildURL(url, {
+    query,
+    param
+  });
+
+  const res = await fetch(requestURL, {
+    method: 'GET',
+    headers
+  });
+
+  const { status } = res;
+  if (HTTPError.isHTTPError(status)) {
+    throw new HTTPError(status);
+  }
+
+  return res.json();
+};
+
+export const postRequest = async <T>(url: string, options: BodyOptions): Promise<T> => {
+  const { headers, query, param, body } = options;
+
+  const requestURL = buildURL(url, {
+    query,
+    param
+  });
+
+  const res = await fetch(requestURL, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+
+  const { status } = res;
+  if (HTTPError.isHTTPError(status)) {
+    throw new HTTPError(status);
+  }
+
+  return res.json();
+};
+
+export const putRequest = async <T>(url: string, options: BodyOptions): Promise<T> => {
+  const { headers, query, param, body } = options;
+
+  const requestURL = buildURL(url, {
+    query,
+    param
+  });
+
+  const res = await fetch(requestURL, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(body)
+  });
+
+  const { status } = res;
+  if (HTTPError.isHTTPError(status)) {
+    throw new HTTPError(status);
+  }
+
+  return res.json();
+};
+
+export const deleteRequest = async <T>(url: string, options: Options): Promise<T> => {
+  const { headers, query, param } = options;
+
+  const requestURL = buildURL(url, {
+    query,
+    param
+  });
+
+  const res = await fetch(requestURL, {
+    method: 'PUT',
+    headers
+  });
+
+  const { status } = res;
+  if (HTTPError.isHTTPError(status)) {
+    throw new HTTPError(status);
+  }
+
+  return res.json();
+};

--- a/frontend/src/constant/actions.ts
+++ b/frontend/src/constant/actions.ts
@@ -1,5 +1,6 @@
 const actions = Object.freeze({
-  ON_FOCUS_DATE_CHANGE: 'ON_FOCUS_DATE_CHANGE'
+  ON_FOCUS_DATE_CHANGE: 'ON_FOCUS_DATE_CHANGE',
+  ON_CASH_HISTORY_CHANGE: 'ON_CASH_HISTORY_CHANGE'
 });
 
 export default actions;

--- a/frontend/src/core/router.ts
+++ b/frontend/src/core/router.ts
@@ -15,6 +15,7 @@ class Router {
     this.routes = {
       [ROUTER_PATH.NOT_FOUND]: new HeaderView($root)
     };
+    this.onStateChange();
   }
 
   listen (): void {

--- a/frontend/src/models/cash-histories.ts
+++ b/frontend/src/models/cash-histories.ts
@@ -1,0 +1,14 @@
+import Model, { ProxyModelDataForm } from '../core/proxy-model';
+import { CashHistoriesResponse } from '../types/cash-history';
+
+export type CashHistoriesData = {
+  cashHistories: CashHistoriesResponse | null;
+}
+
+type InitialData = {
+  cashHistories: ProxyModelDataForm<CashHistoriesResponse | null>;
+}
+
+class CashHistoriesModel extends Model<InitialData> { }
+
+export default CashHistoriesModel;

--- a/frontend/src/models/index.ts
+++ b/frontend/src/models/index.ts
@@ -1,4 +1,5 @@
 import actions from '../constant/actions';
+import CashHistoriesModel from './cash-histories';
 import FocusDateModel from './focus-date';
 
 const models = {
@@ -6,6 +7,12 @@ const models = {
     focusDate: {
       action: actions.ON_FOCUS_DATE_CHANGE,
       data: new Date()
+    }
+  }).getProxy(),
+  cashHistories: new CashHistoriesModel({
+    cashHistories: {
+      action: actions.ON_CASH_HISTORY_CHANGE,
+      data: null
     }
   }).getProxy()
 };

--- a/frontend/src/types/base-response.ts
+++ b/frontend/src/types/base-response.ts
@@ -1,0 +1,3 @@
+export type BaseResponse = {
+  message: string;
+}

--- a/frontend/src/types/cash-history.ts
+++ b/frontend/src/types/cash-history.ts
@@ -1,0 +1,29 @@
+import { BaseResponse } from './base-response';
+import { Category } from './category';
+import { Payment } from './payment';
+
+export type CashHistory = {
+  id: number;
+  price: number;
+  type: number;
+  createdAt: string;
+  category: Category;
+  payment: Payment;
+  userId: number;
+  categoryId: number
+  paymentId: number;
+}
+
+export type CashHistoriesInDay = {
+  year: number;
+  month: number;
+  date: number;
+  day: number;
+  cashHistories: CashHistory[];
+}
+
+export type CashHistoriesResponse = {
+  totalIncome: number;
+  totalExpenditure: number;
+  cashHistories: CashHistoriesInDay[];
+} & BaseResponse;

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,0 +1,6 @@
+export type Category = {
+  id: number;
+  name: string;
+  color: string;
+  userId: number;
+}

--- a/frontend/src/types/payment.ts
+++ b/frontend/src/types/payment.ts
@@ -1,0 +1,5 @@
+export type Payment = {
+  id: number;
+  name: string;
+  userId: number;
+}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,5 @@
+export type User = {
+  id: number,
+  name: string;
+  avatarURL: string;
+}

--- a/frontend/src/utils/cookie.ts
+++ b/frontend/src/utils/cookie.ts
@@ -1,0 +1,23 @@
+class Cookie {
+  get (key: string): string | undefined {
+    return document.cookie.split('; ')
+      .find(row => row.startsWith(key))
+      ?.split('=')[1];
+  }
+
+  set (key: string, value: string, expires?: number) {
+    let cookieString = `${key}=${value}`;
+    if (expires !== undefined) {
+      const expiresDate = new Date();
+      cookieString = `${cookieString}; expires=${expiresDate.setDate(expiresDate.getDate() + expires)}`;
+    }
+
+    document.cookie = cookieString;
+  }
+
+  remove (key: string): void {
+    this.set(key, '', -1);
+  }
+}
+
+export default new Cookie();

--- a/frontend/src/utils/path.ts
+++ b/frontend/src/utils/path.ts
@@ -1,1 +1,33 @@
+type QueryObject = {[key: string]: string | number | null };
+
+const _buildQuerystring = (query: QueryObject): string => {
+  const querystring = Object.keys(query)
+    .map(key => `${key}=${query[key]}`)
+    .join('&');
+
+  return `?${querystring}`;
+};
+
 export const parsePath = (pathname: string): string => pathname.replace('/', '');
+
+export const buildQuerystring = (query: QueryObject): string => {
+  return _buildQuerystring(query);
+};
+
+export const buildURL = (baseURL: string, options: {
+  query?: QueryObject | undefined,
+  param?: string | number
+}): string => {
+  const { query, param } = options;
+  let url = baseURL;
+
+  if (param !== undefined) {
+    url = `${url}/${param}`;
+  }
+
+  if (query !== undefined) {
+    url = `${url}${_buildQuerystring(query)}`;
+  }
+
+  return url;
+};

--- a/frontend/src/view-models/header.ts
+++ b/frontend/src/view-models/header.ts
@@ -4,25 +4,46 @@ import View from '../core/view';
 import ViewModel from '../core/view-model';
 import models from '../models';
 import { FocusDateData } from '../models/focus-date';
+import cashHistoryAPI from '../api/cash-history';
+import { CashHistoriesData } from '../models/cash-histories';
 
 class HeaderViewModel extends ViewModel {
   private focusDateModel: FocusDateData;
+  private cashHistoriesModel: CashHistoriesData;
 
   constructor (view: View) {
     super(view);
     this.focusDateModel = models.focusDate;
+    this.cashHistoriesModel = models.cashHistories;
+    this.fetchCashHistories();
   }
 
   protected subscribe (): void {
     pubsub.subscribe(actions.ON_FOCUS_DATE_CHANGE, () => {
       this.view.build();
     });
+
+    pubsub.subscribe(actions.ON_CASH_HISTORY_CHANGE, () => {
+      this.view.build();
+    });
+  }
+
+  async fetchCashHistories (): Promise<void> {
+    const date = this.focusDateModel.focusDate;
+    setTimeout(async () => {
+      const histories = await cashHistoryAPI.fetchCashHistories(date.getFullYear(), date.getMonth());
+      this.cashHistoriesModel.cashHistories = histories;
+    }, 3000);
   }
 
   get formatTime (): string {
     const time = this.focusDateModel.focusDate;
 
     return time.toString();
+  }
+
+  get cashHistories (): string | undefined {
+    return this.cashHistoriesModel.cashHistories?.message;
   }
 
   onNextMonthClicked (): void {

--- a/frontend/src/views/header/index.ts
+++ b/frontend/src/views/header/index.ts
@@ -23,6 +23,9 @@ class HeaderView extends View {
     this.$target.innerHTML = `
       <header>
         ${this.headerViewModel.formatTime}
+        <div>
+          ${this.headerViewModel.cashHistories}
+        </div>
       </header>
     `;
 


### PR DESCRIPTION
## :bookmark_tabs: #40 가계 내역 조회 및 타입 정의



## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 2시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* HTTPError 클래스를 통한 에러 핸들링
* 도메인별 타입 정의
* Cookie, Path 관련 유틸리티 개발
* Request 모듈 개발 및 메서드별 요청 개발
* 가계 내역 모델 생성
* 가계 내역 조회



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점



- `Header`는 다시 수정을 해야합니다!
