### PR TITLE
[fix/cash history api total income expenditure] 가계 내역 조회 시 전체 지출, 수입 응답

### DIFF
--- a/backend/src/services/cash-history.service.ts
+++ b/backend/src/services/cash-history.service.ts
@@ -12,6 +12,7 @@ import CashHistoryCreateRequest from '../request/cash-history/cash-history-creat
 import CashHistoryUpdateRequest from '../request/cash-history/cash-history-update.request';
 import Builder from '../utils/builder';
 import { getDaysInMonth } from '../utils/date';
+import { CashHistories } from '../enums/cash-history.enum';
 
 type GroupedCashHistory = {
   year: number,
@@ -19,6 +20,8 @@ type GroupedCashHistory = {
   date: number,
   day: number,
   cashHistories: CashHistory[],
+  income: number;
+  expenditure: number;
 }
 
 class CashHistoryService {
@@ -34,16 +37,31 @@ class CashHistoryService {
         month,
         date,
         day,
-        cashHistories: []
+        cashHistories: [],
+        income: 0,
+        expenditure: 0
       });
     }
 
+    let totalIncome = 0;
+    let totalExpenditure = 0;
     cashHistories.forEach((cashHistory) => {
       const date = cashHistory.createdAt.getDate();
       groupedCashHistories[date].cashHistories.push(cashHistory);
+      if (cashHistory.type === CashHistories.Income) {
+        totalIncome += cashHistory.price;
+        groupedCashHistories[date].income += cashHistory.price;
+      } else {
+        totalExpenditure += cashHistory.price;
+        groupedCashHistories[date].expenditure += cashHistory.price;
+      }
     });
 
-    return groupedCashHistories;
+    return {
+      totalIncome,
+      totalExpenditure,
+      groupedCashHistories
+    };
   }
 
   async findCashHistories (user: User): Promise<CashHistory[]> {


### PR DESCRIPTION
## :bookmark_tabs: #39 가계 내역 조회 시 전체 지출, 수입 응답



## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 한달 전체의 지출, 수입의 합계 응답
* 하루의 전체 지출, 수입 합계 응답



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

