### PR TITLE
[fix/cash history calendar api] 한달의 가계 내역 조회 API에 Date 인덱스 밀림 수정

### DIFF
--- a/backend/src/services/cash-history.service.ts
+++ b/backend/src/services/cash-history.service.ts
@@ -47,13 +47,13 @@ class CashHistoryService {
     let totalExpenditure = 0;
     cashHistories.forEach((cashHistory) => {
       const date = cashHistory.createdAt.getDate();
-      groupedCashHistories[date].cashHistories.push(cashHistory);
+      groupedCashHistories[date - 1].cashHistories.push(cashHistory);
       if (cashHistory.type === CashHistories.Income) {
         totalIncome += cashHistory.price;
-        groupedCashHistories[date].income += cashHistory.price;
+        groupedCashHistories[date - 1].income += cashHistory.price;
       } else {
         totalExpenditure += cashHistory.price;
-        groupedCashHistories[date].expenditure += cashHistory.price;
+        groupedCashHistories[date - 1].expenditure += cashHistory.price;
       }
     });
 


### PR DESCRIPTION
## :bookmark_tabs: #71  한달의 가계 내역 조회 API에 Date 인덱스 밀림 수정

가계 내역 조회 시 date가 하루씩 밀리는 버그 수정

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 한달 가계 내역 조회 시 하루씩 밀리는 부분 수정
  * `array[date]`를 넣어주어 생긴 오류로 `array[date - 1]`에 넣어주었습니다



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점