### PR TITLE
[feature/calendar page elements refactor] 캘린더 페이지 이벤트 델리게이션 적용 및 캘린더 태그 변경

### DIFF
--- a/frontend/src/ui-elements/calendar/calendar-cell/index.css
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.css
@@ -4,6 +4,7 @@
   position: relative;
   border-left: 1px solid var(--line);
   border-top: 1px solid var(--line);
+  cursor: pointer;
 }
 
 .calendar-cell > * {

--- a/frontend/src/ui-elements/calendar/calendar-cell/index.css
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.css
@@ -1,9 +1,9 @@
 .calendar-cell {
-  --side-size: calc(var(--inner-width) / 7);
   width: var(--side-size);
   height: var(--side-size);
   position: relative;
-  border: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+  border-top: 1px solid var(--line);
 }
 
 .calendar-cell > * {

--- a/frontend/src/ui-elements/calendar/calendar-cell/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.ts
@@ -1,6 +1,7 @@
 import UIElement from '../../../core/ui-element';
 import { CashHistoriesInDay } from '../../../types/cash-history';
 import { isSameDate } from '../../../utils/date';
+import { formatNumber } from '../../../utils/formatter';
 import CalendarDetailUIElement from '../calendar-detail';
 
 import './index.css';
@@ -44,9 +45,9 @@ class CalendarCellUIElement extends UIElement {
     this.$element.innerHTML = `
       <div class="calendar-cell__container">
         <div class="calendar-cell__price-wrapper">
-          <span class="calendar-cell__price calendar-cell__price--income">${income}</span>
-          <span class="calendar-cell__price calendar-cell__price--expenditure">${expenditure}</span>
-          <span class="calendar-cell__price calendar-cell__price--total">${income - expenditure}</span>
+          <span class="calendar-cell__price calendar-cell__price--income">${formatNumber(income)}</span>
+          <span class="calendar-cell__price calendar-cell__price--expenditure">${formatNumber(expenditure)}</span>
+          <span class="calendar-cell__price calendar-cell__price--total">${formatNumber(income - expenditure)}</span>
         </div>
 
         <div class="calendar-cell__date-wrapper">

--- a/frontend/src/ui-elements/calendar/calendar-cell/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.ts
@@ -11,8 +11,7 @@ class CalendarCellUIElement extends UIElement {
 
   constructor ($target: HTMLElement, cashHistoriesInDay?: CashHistoriesInDay) {
     super($target, {
-      tag: 'td',
-      className: 'calendar-cell'
+      className: 'calendar__td calendar-cell'
     });
     this.cashHistoriesInDay = cashHistoriesInDay;
   }

--- a/frontend/src/ui-elements/calendar/calendar-cell/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.ts
@@ -58,13 +58,6 @@ class CalendarCellUIElement extends UIElement {
     `;
   }
 
-  // onDocumentClicked (e: Event): void {
-  //   const target = e.target as HTMLElement;
-  //   if (target !== this.$element) {
-  //     this.calendarDetailUIElement?.disappear();
-  //   }
-  // }
-
   protected addListener (): void {
     // no event
   }

--- a/frontend/src/ui-elements/calendar/calendar-cell/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.ts
@@ -45,9 +45,9 @@ class CalendarCellUIElement extends UIElement {
     this.$element.innerHTML = `
       <div class="calendar-cell__container">
         <div class="calendar-cell__price-wrapper">
-          <span class="calendar-cell__price calendar-cell__price--income">${formatNumber(income)}</span>
-          <span class="calendar-cell__price calendar-cell__price--expenditure">${formatNumber(expenditure)}</span>
-          <span class="calendar-cell__price calendar-cell__price--total">${formatNumber(income - expenditure)}</span>
+          ${income > 0 ? `<span class="calendar-cell__price calendar-cell__price--income">${formatNumber(income)}</span>` : ''}
+          ${expenditure > 0 ? `<span class="calendar-cell__price calendar-cell__price--expenditure">${formatNumber(expenditure)}</span>` : ''}
+          ${income > 0 && expenditure > 0 ? `<span class="calendar-cell__price calendar-cell__price--total">${formatNumber(income - expenditure)}</span>` : ''}
         </div>
 
         <div class="calendar-cell__date-wrapper">

--- a/frontend/src/ui-elements/calendar/calendar-cell/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-cell/index.ts
@@ -10,10 +10,11 @@ class CalendarCellUIElement extends UIElement {
   private cashHistoriesInDay: CashHistoriesInDay | undefined;
   private calendarDetailUIElement: CalendarDetailUIElement | undefined;
 
-  constructor ($target: HTMLElement, cashHistoriesInDay?: CashHistoriesInDay) {
+  constructor ($target: HTMLElement, cellSequence: number, cashHistoriesInDay?: CashHistoriesInDay) {
     super($target, {
-      className: 'calendar__td calendar-cell'
+      className: `calendar__td calendar-cell calendar-cell--${cellSequence}`
     });
+    this.$element.dataset.sequence = cellSequence.toString();
     this.cashHistoriesInDay = cashHistoriesInDay;
   }
 
@@ -57,20 +58,15 @@ class CalendarCellUIElement extends UIElement {
     `;
   }
 
-  onDocumentClicked (e: Event): void {
-    const target = e.target as HTMLElement;
-    if (target !== this.$element) {
-      this.calendarDetailUIElement?.disappear();
-    }
-  }
+  // onDocumentClicked (e: Event): void {
+  //   const target = e.target as HTMLElement;
+  //   if (target !== this.$element) {
+  //     this.calendarDetailUIElement?.disappear();
+  //   }
+  // }
 
   protected addListener (): void {
-    if (this.calendarDetailUIElement !== undefined) {
-      document.addEventListener('click', this.onDocumentClicked.bind(this));
-
-      this.$element.addEventListener('click',
-        this.calendarDetailUIElement.toggle.bind(this.calendarDetailUIElement));
-    }
+    // no event
   }
 
   protected mount (): void {

--- a/frontend/src/ui-elements/calendar/calendar-detail-item/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-detail-item/index.ts
@@ -1,6 +1,7 @@
 import UIElement from '../../../core/ui-element';
 import { CashHistories } from '../../../enums/cash-history.enum';
 import { CashHistory } from '../../../types/cash-history';
+import { formatNumber } from '../../../utils/formatter';
 
 import './index.css';
 
@@ -26,7 +27,7 @@ class CalendarDetailItemUIElement extends UIElement {
       </div>
 
       <span class="calendar-detail__price calendar-detail__price--${type === CashHistories.Income ? 'income' : 'expenditure'}">
-        ${price}
+        ${formatNumber(price)}
       </span>
     `;
   }

--- a/frontend/src/ui-elements/calendar/calendar-detail-item/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-detail-item/index.ts
@@ -1,4 +1,5 @@
 import UIElement from '../../../core/ui-element';
+import { CashHistories } from '../../../enums/cash-history.enum';
 import { CashHistory } from '../../../types/cash-history';
 
 import './index.css';
@@ -15,7 +16,6 @@ class CalendarDetailItemUIElement extends UIElement {
 
   protected render (): void {
     const { price, category, type, content } = this.cashHistory;
-    // type enum 변경 필요
     this.$element.innerHTML = `
       <div class="calendar-detail__info-wrapper">
         <div class="calendar-detail__category"
@@ -25,7 +25,7 @@ class CalendarDetailItemUIElement extends UIElement {
         <span class="calendar-detail__content">${content}</span>
       </div>
 
-      <span class="calendar-detail__price calendar-detail__price--${type === 0 ? 'income' : 'expenditure'}">
+      <span class="calendar-detail__price calendar-detail__price--${type === CashHistories.Income ? 'income' : 'expenditure'}">
         ${price}
       </span>
     `;

--- a/frontend/src/ui-elements/calendar/calendar-detail/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-detail/index.ts
@@ -19,15 +19,6 @@ class CalendarDetailUIElement extends UIElement {
     `;
   }
 
-  toggle (): void {
-    this.$element.classList.toggle('disappear');
-    this.$element.classList.toggle('appear');
-  }
-
-  disappear (): void {
-    this.$element.classList.replace('appear', 'disappear');
-  }
-
   protected addListener (): void {
     // no event
   }

--- a/frontend/src/ui-elements/calendar/calendar-total-price/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar-total-price/index.ts
@@ -1,5 +1,6 @@
 import UIElement from '../../../core/ui-element';
 import { TotalPrices } from '../../../types/cash-history';
+import { formatNumber } from '../../../utils/formatter';
 
 import './index.css';
 
@@ -19,18 +20,18 @@ class CalendarTotalPriceUIElement extends UIElement {
     <div class="calendar-total-price__info-wrapper">
       <div class="calendar-total-price__content">
         <span class="calendar-total-price__label">총 수입</span>
-        <span class="calendar-total-price__price">${totalIncome}</span>
+        <span class="calendar-total-price__price">${formatNumber(totalIncome)}</span>
       </div>
 
       <div class="calendar-total-price__content">
         <span class="calendar-total-price__label">총 지출</span>
-        <span class="calendar-total-price__price">${totalExpenditure}</span>
+        <span class="calendar-total-price__price">${formatNumber(totalExpenditure)}</span>
       </div>
     </div>
 
     <div class="calendar-total-price__content">
       <span class="calendar-total-price__label">총계</span>
-      <span class="calendar-total-price__price">${totalPrice}</span>
+      <span class="calendar-total-price__price">${formatNumber(totalPrice)}</span>
     <div>
     `;
   }

--- a/frontend/src/ui-elements/calendar/calendar/index.css
+++ b/frontend/src/ui-elements/calendar/calendar/index.css
@@ -1,49 +1,53 @@
 .calendar {
   --calendar-radius: 8px;
-  border-collapse: separate;
+  --side-size: calc(var(--inner-width) / 7);
 }
 
-.calendar thead {
-  width: 100%;
+.calendar__thead {
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--line);
-  border-radius: var(--calendar-radius);
-}
-
-.calendar th {
   background-color: var(--off-white);
-  padding: 15px 0;
+  border-radius: var(--calendar-radius);
+  padding: 12px 0;
+  border: 1px solid var(--line);
 }
 
-.calendar thead th:first-child {
-  border-top-left-radius: var(--calendar-radius);
-  border-bottom-left-radius: var(--calendar-radius);
+.calendar__trow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.calendar thead th:last-child {
-  border-top-right-radius: var(--calendar-radius);
-  border-end-end-radius: var(--calendar-radius);
+.calendar__td--thead {
+  width: var(--side-size);
+  text-align: center;
 }
 
-.calendar tbody {
-  position: relative;
-  top: 20px;
+.calendar__tbody {
+  margin-top: 20px;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
   border-radius: var(--calendar-radius);
 }
 
-.calendar tbody tr:first-child td:first-child {
+.calendar__tbody .calendar__trow:first-child .calendar__td:first-child {
   border-top-left-radius: var(--calendar-radius);
 }
 
-.calendar tbody tr:first-child td:last-child {
+.calendar__tbody .calendar__trow:first-child .calendar__td:last-child {
   border-top-right-radius: var(--calendar-radius);
 }
 
-.calendar tbody tr:last-child td:first-child {
+.calendar__tbody .calendar__trow:last-child .calendar__td:first-child {
   border-bottom-left-radius: var(--calendar-radius);
 }
 
-.calendar tbody tr:last-child td:last-child {
+.calendar__tbody .calendar__trow:last-child .calendar__td:last-child {
   border-bottom-right-radius: var(--calendar-radius);
+}
+
+.calendar__tbody .calendar__trow:last-child .calendar__td {
+  border-bottom: 1px solid var(--line);
+}
+
+.calendar__tbody .calendar__trow .calendar__td:last-child {
+  border-right: 1px solid var(--line);
 }

--- a/frontend/src/ui-elements/calendar/calendar/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar/index.ts
@@ -15,8 +15,33 @@ class CalendarUIElement extends UIElement {
     this.cashHistoriesInDays = cashHistoriesInDays;
   }
 
+  onCalendarCellClicked (e: Event): void {
+    $('.calendar-cell__detail.appear')?.classList.replace('appear', 'disappear');
+
+    const target = e.target as HTMLElement;
+    const { sequence } = target.dataset;
+    if (sequence === undefined) {
+      return;
+    }
+
+    const $detail = $(`.calendar-cell--${sequence} .calendar-cell__detail`);
+    $detail?.classList.toggle('disappear');
+    $detail?.classList.toggle('appear');
+  }
+
+  onDocumentClicked (e: Event): void {
+    const target = e.target as HTMLElement;
+    const { sequence } = target.dataset;
+    if (sequence !== undefined && $(`.calendar-cell--${sequence} .calendar-cell__detail.appear`)) {
+      return;
+    }
+
+    $('.calendar-cell__detail.appear')?.classList.replace('appear', 'disappear');
+  }
+
   protected addListener (): void {
-    // no event
+    document.addEventListener('click', this.onDocumentClicked);
+    $('.calendar__tbody')?.addEventListener('click', this.onCalendarCellClicked);
   }
 
   protected render (): void {
@@ -59,14 +84,15 @@ class CalendarUIElement extends UIElement {
     let cellCount = firstDayInMonth;
 
     let $tr = this.newTableRow();
+    let cellSequence = 0;
 
     // 비워있는 cell로 1일전까지 채움
     for (let i = 0; i < firstDayInMonth; i += 1) {
-      new CalendarCellUIElement($tr).build();
+      new CalendarCellUIElement($tr, cellSequence++).build();
     }
 
     this.cashHistoriesInDays.forEach((cashHistory) => {
-      new CalendarCellUIElement($tr, cashHistory).build();
+      new CalendarCellUIElement($tr, cellSequence++, cashHistory).build();
       cellCount += 1;
 
       if (cellCount % 7 === 0) {
@@ -77,7 +103,7 @@ class CalendarUIElement extends UIElement {
 
     if (cellCount % 7 !== 0) {
       for (let i = 0; i < 7 - cellCount % 7; i += 1) {
-        new CalendarCellUIElement($tr).build();
+        new CalendarCellUIElement($tr, cellSequence++).build();
       }
       this.appendRow($tr);
     }

--- a/frontend/src/ui-elements/calendar/calendar/index.ts
+++ b/frontend/src/ui-elements/calendar/calendar/index.ts
@@ -10,8 +10,7 @@ class CalendarUIElement extends UIElement {
 
   constructor ($target: HTMLElement, cashHistoriesInDays: CashHistoriesInDay[]) {
     super($target, {
-      className: 'calendar',
-      tag: 'table'
+      className: 'calendar'
     });
     this.cashHistoriesInDays = cashHistoriesInDays;
   }
@@ -22,25 +21,25 @@ class CalendarUIElement extends UIElement {
 
   protected render (): void {
     this.$element.innerHTML = `
-      <thead>
-        <tr>
-          <th>일</th>
-          <th>월</th>
-          <th>화</th>
-          <th>수</th>
-          <th>목</th>
-          <th>금</th>
-          <th>토</th>
-        </tr>
-      </thead>
+      <div class="calendar__thead">
+        <div class="calendar__trow">
+          <div class="calendar__td--thead">일</div>
+          <div class="calendar__td--thead">월</div>
+          <div class="calendar__td--thead">화</div>
+          <div class="calendar__td--thead">수</div>
+          <div class="calendar__td--thead">목</div>
+          <div class="calendar__td--thead">금</div>
+          <div class="calendar__td--thead">토</div>
+        </div>
+      </div>
 
-      <tbody>
-      </tbody>
+      <div class="calendar__tbody">
+      </div>
     `;
   }
 
-  private appendRow ($tr: HTMLTableRowElement): void {
-    const $tbody = $('.calendar>tbody');
+  private appendRow ($tr: HTMLDivElement): void {
+    const $tbody = $('.calendar__tbody');
     if ($tbody === null) {
       return;
     }
@@ -48,11 +47,18 @@ class CalendarUIElement extends UIElement {
     $tbody.appendChild($tr);
   }
 
+  private newTableRow (): HTMLDivElement {
+    const $tr = document.createElement('div');
+    $tr.className = 'calendar__trow';
+
+    return $tr;
+  }
+
   protected mount (): void {
     const firstDayInMonth = this.cashHistoriesInDays[0].day;
     let cellCount = firstDayInMonth;
 
-    let $tr = document.createElement('tr');
+    let $tr = this.newTableRow();
 
     // 비워있는 cell로 1일전까지 채움
     for (let i = 0; i < firstDayInMonth; i += 1) {
@@ -65,7 +71,7 @@ class CalendarUIElement extends UIElement {
 
       if (cellCount % 7 === 0) {
         this.appendRow($tr);
-        $tr = document.createElement('tr');
+        $tr = this.newTableRow();
       }
     });
 


### PR DESCRIPTION
## :bookmark_tabs: #75 캘린더 페이지 이벤트 델리게이션 적용 및 캘린더 태그 변경

캘린더 페이지 `<table>` 태그 제거 및 이벤트 델리게이션 적용, 리펙토링

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 1.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 캘린더 페이지의 셀 클릭 시 팝업 보여주는 부분 이벤트 델리게이션으로 처리
* 캘린더의 `<table>`태그를 제거한 후 `<div>`로 작업
* 수입, 지출, 총계를 표시해야될 부분만 표시하여 UX 개선

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점


<참고 - 지출, 수입이 없을경우 `0`으로 표시하지 않음. 지출, 수입 중 하나만 존재할 경우 총계 표시하지 않음>
![스크린샷 2021-08-03 오후 7 19 22](https://user-images.githubusercontent.com/49791336/127999819-aceac55d-07f8-4ab5-b23e-569cff0e8c8a.png)
