### PR TITLE
[feature/category type attribute] 카테고리 타입 속성 추가 

### DIFF
--- a/backend/src/entities/category.ts
+++ b/backend/src/entities/category.ts
@@ -1,4 +1,5 @@
 import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, ManyToOne, RelationId } from 'typeorm';
+import { CashHistories } from '../enums/cash-history.enum';
 import User from './user';
 
 @Entity('category')
@@ -11,6 +12,12 @@ class Category {
 
   @Column()
   color!: string;
+
+  @Column({
+    type: 'enum',
+    enum: CashHistories
+  })
+  type!: CashHistories;
 
   @ManyToOne(() => User, {
     onDelete: 'CASCADE'

--- a/backend/src/request/cash-history/cash-history-create.request.ts
+++ b/backend/src/request/cash-history/cash-history-create.request.ts
@@ -1,5 +1,4 @@
-import { IsEnum, IsInt, IsNotEmpty, Length } from 'class-validator';
-import { CashHistories } from '../../enums/cash-history.enum';
+import { IsInt, IsNotEmpty, Length } from 'class-validator';
 import BaseRequest from '../base.request';
 
 class CashHistoryCreateRequest extends BaseRequest {
@@ -9,12 +8,6 @@ class CashHistoryCreateRequest extends BaseRequest {
   @IsNotEmpty()
   @Length(1, 50)
   content: string;
-
-  @IsEnum([
-    CashHistories.Income,
-    CashHistories.Expenditure
-  ])
-  type: CashHistories;
 
   @IsInt()
   categoryId: number;
@@ -26,7 +19,6 @@ class CashHistoryCreateRequest extends BaseRequest {
     super();
     this.price = cashHistoryCreateRequest.price;
     this.content = cashHistoryCreateRequest.content;
-    this.type = cashHistoryCreateRequest.type;
     this.categoryId = cashHistoryCreateRequest.categoryId;
     this.paymentId = cashHistoryCreateRequest.paymentId;
   }

--- a/backend/src/request/cash-history/cash-history-update.request.ts
+++ b/backend/src/request/cash-history/cash-history-update.request.ts
@@ -1,5 +1,4 @@
-import { IsEnum, IsInt, IsNotEmpty, Length } from 'class-validator';
-import { CashHistories } from '../../enums/cash-history.enum';
+import { IsInt, IsNotEmpty, Length } from 'class-validator';
 import BaseRequest from '../base.request';
 
 class CashHistoryUpdateRequest extends BaseRequest {
@@ -9,12 +8,6 @@ class CashHistoryUpdateRequest extends BaseRequest {
   @IsNotEmpty()
   @Length(1, 50)
   content: string;
-
-  @IsEnum([
-    CashHistories.Income,
-    CashHistories.Expenditure
-  ])
-  type: CashHistories;
 
   @IsInt()
   categoryId: number;
@@ -26,7 +19,6 @@ class CashHistoryUpdateRequest extends BaseRequest {
     super();
     this.price = cashHistoryCreateRequest.price;
     this.content = cashHistoryCreateRequest.content;
-    this.type = cashHistoryCreateRequest.type;
     this.categoryId = cashHistoryCreateRequest.categoryId;
     this.paymentId = cashHistoryCreateRequest.paymentId;
   }

--- a/backend/src/request/category.request/category-create.request.ts
+++ b/backend/src/request/category.request/category-create.request.ts
@@ -1,4 +1,5 @@
-import { IsNotEmpty, Length, Matches } from 'class-validator';
+import { IsEnum, IsNotEmpty, Length, Matches } from 'class-validator';
+import { CashHistories } from '../../enums/cash-history.enum';
 import BaseRequest from '../base.request';
 
 class CategoryCreateRequest extends BaseRequest {
@@ -9,10 +10,14 @@ class CategoryCreateRequest extends BaseRequest {
   @Matches(/^#(?:[0-9a-f]{3}){1,2}$/i)
   color: string;
 
-  constructor (categoryCreateReqeust: CategoryCreateRequest) {
+  @IsEnum(CashHistories)
+  type: CashHistories;
+
+  constructor (categoryCreateRequest: CategoryCreateRequest) {
     super();
-    this.name = categoryCreateReqeust.name;
-    this.color = categoryCreateReqeust.color;
+    this.name = categoryCreateRequest.name;
+    this.color = categoryCreateRequest.color;
+    this.type = categoryCreateRequest.type;
   }
 }
 export default CategoryCreateRequest;

--- a/backend/src/request/category.request/category-create.request.ts
+++ b/backend/src/request/category.request/category-create.request.ts
@@ -10,7 +10,10 @@ class CategoryCreateRequest extends BaseRequest {
   @Matches(/^#(?:[0-9a-f]{3}){1,2}$/i)
   color: string;
 
-  @IsEnum(CashHistories)
+  @IsEnum([
+    CashHistories.Income,
+    CashHistories.Expenditure
+  ])
   type: CashHistories;
 
   constructor (categoryCreateRequest: CategoryCreateRequest) {

--- a/backend/src/services/cash-history.service.ts
+++ b/backend/src/services/cash-history.service.ts
@@ -82,7 +82,7 @@ class CashHistoryService {
 
   async createCashHistory (user: User, cashHistoryCreateRequest: CashHistoryCreateRequest) {
     const { id } = user;
-    const { price, content, type, categoryId, paymentId } = cashHistoryCreateRequest;
+    const { price, content, categoryId, paymentId } = cashHistoryCreateRequest;
     const category = await getCustomRepository(CategoryRepository).findOne(categoryId);
     const payment = await getCustomRepository(PaymentRepository).findOne(paymentId);
 
@@ -97,7 +97,7 @@ class CashHistoryService {
     const cashHistory = Builder<CashHistory>()
       .price(price)
       .content(content)
-      .type(type)
+      .type(category.type)
       .category(category)
       .payment(payment)
       .user(user)
@@ -108,7 +108,7 @@ class CashHistoryService {
 
   async updateCashHistory (user: User, cashHistoryId: number, cashHistoryUpdateRequest: CashHistoryUpdateRequest) {
     const { id } = user;
-    const { price, content, type, categoryId, paymentId } = cashHistoryUpdateRequest;
+    const { price, content, categoryId, paymentId } = cashHistoryUpdateRequest;
     const category = await getCustomRepository(CategoryRepository).findOne(categoryId);
     const payment = await getCustomRepository(PaymentRepository).findOne(paymentId);
 
@@ -132,7 +132,7 @@ class CashHistoryService {
     const updateCashHistory = Builder<CashHistory>()
       .price(price)
       .content(content)
-      .type(type)
+      .type(category.type)
       .category(category)
       .payment(payment)
       .build();

--- a/backend/src/services/category.service.ts
+++ b/backend/src/services/category.service.ts
@@ -17,6 +17,7 @@ class CategoryService {
     const newCategory = Builder<Category>()
       .name(category.name)
       .color(category.color)
+      .type(category.type)
       .user(user)
       .build();
 

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,3 +1,4 @@
+import { CashHistories } from '../enums/cash-history.enum';
 import { BaseResponse } from './base-response';
 
 export type Category = {
@@ -5,6 +6,7 @@ export type Category = {
   name: string;
   color: string;
   userId: number;
+  type: CashHistories;
 }
 
 export type CategoriesResponse = {


### PR DESCRIPTION
## :bookmark_tabs: #77 카테고리 타입 속성 추가

프론트엔드, 백엔드 카테고리 타입 속성 추가

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [ ] Warning Message가 발생하지 않았나요?
- [ ] Coding Convention을 준수했나요?
- [ ] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 프론트엔드, 백엔드 카테고리 모델 및 타입에 `type: CashHistories` 속성 추가
* 해당 작업으로 가계 내역 생성/수정 시 따로 `type`을 받지 않고 카테고리의 타입을 참고하여 생성



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

