### PR TITLE
[feature/cash history date request] 가계 내역 생성/수정 시 date를 수신

### DIFF
--- a/backend/src/request/cash-history/cash-history-create.request.ts
+++ b/backend/src/request/cash-history/cash-history-create.request.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, Length } from 'class-validator';
+import { IsInt, IsNotEmpty, Length, Matches } from 'class-validator';
 import BaseRequest from '../base.request';
 
 class CashHistoryCreateRequest extends BaseRequest {
@@ -15,12 +15,17 @@ class CashHistoryCreateRequest extends BaseRequest {
   @IsInt()
   paymentId: number;
 
+  // yyyyMMdd
+  @Matches(/^([12]\d{3}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))$/)
+  date!: string;
+
   constructor (cashHistoryCreateRequest: CashHistoryCreateRequest) {
     super();
     this.price = cashHistoryCreateRequest.price;
     this.content = cashHistoryCreateRequest.content;
     this.categoryId = cashHistoryCreateRequest.categoryId;
     this.paymentId = cashHistoryCreateRequest.paymentId;
+    this.date = cashHistoryCreateRequest.date;
   }
 }
 

--- a/backend/src/request/cash-history/cash-history-update.request.ts
+++ b/backend/src/request/cash-history/cash-history-update.request.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, Length } from 'class-validator';
+import { IsInt, IsNotEmpty, Length, Matches } from 'class-validator';
 import BaseRequest from '../base.request';
 
 class CashHistoryUpdateRequest extends BaseRequest {
@@ -15,12 +15,17 @@ class CashHistoryUpdateRequest extends BaseRequest {
   @IsInt()
   paymentId: number;
 
+  // yyyyMMdd
+  @Matches(/^([12]\d{3}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))$/)
+  date!: string;
+
   constructor (cashHistoryCreateRequest: CashHistoryUpdateRequest) {
     super();
     this.price = cashHistoryCreateRequest.price;
     this.content = cashHistoryCreateRequest.content;
     this.categoryId = cashHistoryCreateRequest.categoryId;
     this.paymentId = cashHistoryCreateRequest.paymentId;
+    this.date = cashHistoryCreateRequest.date;
   }
 }
 

--- a/backend/src/services/cash-history.service.ts
+++ b/backend/src/services/cash-history.service.ts
@@ -11,7 +11,7 @@ import PaymentRepository from '../repositories/payment.repository';
 import CashHistoryCreateRequest from '../request/cash-history/cash-history-create.request';
 import CashHistoryUpdateRequest from '../request/cash-history/cash-history-update.request';
 import Builder from '../utils/builder';
-import { getDaysInMonth } from '../utils/date';
+import { getDaysInMonth, yyyyMMdd2Date } from '../utils/date';
 import { CashHistories } from '../enums/cash-history.enum';
 
 type GroupedCashHistory = {
@@ -82,7 +82,7 @@ class CashHistoryService {
 
   async createCashHistory (user: User, cashHistoryCreateRequest: CashHistoryCreateRequest) {
     const { id } = user;
-    const { price, content, categoryId, paymentId } = cashHistoryCreateRequest;
+    const { price, content, categoryId, paymentId, date } = cashHistoryCreateRequest;
     const category = await getCustomRepository(CategoryRepository).findOne(categoryId);
     const payment = await getCustomRepository(PaymentRepository).findOne(paymentId);
 
@@ -101,6 +101,7 @@ class CashHistoryService {
       .category(category)
       .payment(payment)
       .user(user)
+      .createdAt(yyyyMMdd2Date(date))
       .build();
 
     await getCustomRepository(CashHistoryRepository).insert(cashHistory);
@@ -108,7 +109,7 @@ class CashHistoryService {
 
   async updateCashHistory (user: User, cashHistoryId: number, cashHistoryUpdateRequest: CashHistoryUpdateRequest) {
     const { id } = user;
-    const { price, content, categoryId, paymentId } = cashHistoryUpdateRequest;
+    const { price, content, categoryId, paymentId, date } = cashHistoryUpdateRequest;
     const category = await getCustomRepository(CategoryRepository).findOne(categoryId);
     const payment = await getCustomRepository(PaymentRepository).findOne(paymentId);
 
@@ -135,6 +136,7 @@ class CashHistoryService {
       .type(category.type)
       .category(category)
       .payment(payment)
+      .createdAt(yyyyMMdd2Date(date))
       .build();
 
     await getCustomRepository(CashHistoryRepository).update(cashHistoryId, updateCashHistory);

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -1,3 +1,17 @@
+import { isNumberString } from 'class-validator';
+
 export const getDaysInMonth = (year: number, month: number): number => {
   return new Date(year, month, 0).getDate();
+};
+
+export const yyyyMMdd2Date = (yyyyMMdd: string): Date => {
+  const year = yyyyMMdd.slice(0, 4);
+  const month = yyyyMMdd.slice(4, 6);
+  const date = yyyyMMdd.slice(6, 8);
+
+  if (!(isNumberString(year) && isNumberString(month) && isNumberString(date))) {
+    throw new Error(`${yyyyMMdd} 은 yyyyMMdd 양식에 맞지 않습니다`);
+  }
+
+  return new Date(Number(year), Number(month) - 1, Number(date));
 };


### PR DESCRIPTION
## :bookmark_tabs: #79 가계 내역 생성/조회 시 date를 받아옴

가계 내역 생성/수정 시 date를 받아서 저장 해당 날짜로 저장

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* `yyyyMMdd`를 `Date`객체로 변환하는 `yyyyMMdd2Date` 유틸리티
* 가계 내역 생성, 수정 시 `date (yyyyMMdd 형식)` 데이터를 body에 함께 요청받음



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
