### PR TITLE
[feature/expenditure in month view] 현재 focus된 달의 지출 시각화 View

### DIFF
--- a/frontend/src/ui-elements/chart/pie-chart/index.ts
+++ b/frontend/src/ui-elements/chart/pie-chart/index.ts
@@ -1,0 +1,195 @@
+import UIElement from '../../../core/ui-element';
+import { calcDegreeWithLines, toRadian } from '../../../utils/math';
+import { $ } from '../../../utils/selector';
+import { sleep } from '../../../utils/time';
+
+export type PieChartInputData = {
+  value: number;
+  name: string;
+  color: string;
+  label: string;
+}
+
+type ChartData = {
+  value: number;
+  name: string;
+  color: string;
+  degree: number;
+  label: string;
+}
+
+const TITLE_FONT = '16px Arial';
+const SUB_TITLE_FONT = '14px Arial';
+
+class PieChartUIElement extends UIElement {
+  private chartData: ChartData[];
+  private width: number;
+  private height: number;
+  private centerX: number;
+  private centerY: number;
+  private radius: number;
+  private $canvas?: HTMLCanvasElement;
+  private ctx?: CanvasRenderingContext2D;
+
+  constructor ($target: HTMLElement, chartInputData: PieChartInputData[], width: number, height: number) {
+    super($target, {
+      className: 'pie-chart-wrapper'
+    });
+
+    this.width = width;
+    this.height = height;
+    this.centerX = this.width / 2;
+    this.centerY = this.height / 2;
+    this.radius = this.width * 0.3;
+    console.log(chartInputData);
+    this.chartData = this.formatChartData(chartInputData);
+  }
+
+  protected render (): void {
+    this.$element.innerHTML = `
+        <canvas class="pie-chart" width="${this.width}" height="${this.height}"></canvas>
+    `;
+  }
+
+  protected addListener (): void {
+    this.$canvas?.addEventListener('mousemove', this.onMouseMove.bind(this));
+  }
+
+  protected mount (): void {
+    const $canvas = $('.pie-chart') as HTMLCanvasElement;
+    if ($canvas === null) {
+      return;
+    }
+
+    this.$canvas = $canvas;
+    this.ctx = $canvas.getContext('2d') ?? undefined;
+
+    this.drawWithAnimation(0);
+  }
+
+  private formatChartData (data: PieChartInputData[]) {
+    const total = data.reduce((sum, curr) => sum + curr.value, 0);
+
+    return data.map(item => {
+      return {
+        name: item.name,
+        value: item.value,
+        degree: 360 * (item.value / total),
+        color: item.color,
+        label: item.label
+      };
+    });
+  }
+
+  private async drawWithAnimation (endDegree: number): Promise<void> {
+    if (endDegree <= 360) {
+      this.ctx?.clearRect(0, 0, this.width, this.height);
+      this.draw(endDegree);
+      await sleep(1);
+
+      requestAnimationFrame(() => {
+        this.drawWithAnimation(endDegree + 10);
+      });
+    }
+  }
+
+  private draw (limitDegree: number, focusDegree?: number) {
+    let currentDegree = 0;
+
+    const { ctx, centerX, centerY, radius } = this;
+    if (ctx === undefined) {
+      return;
+    }
+
+    for (const data of this.chartData) {
+      const isInFocus = focusDegree && currentDegree < focusDegree && focusDegree < currentDegree + data.degree;
+      ctx.beginPath();
+      ctx.moveTo(centerX, centerY);
+      const isLimited = currentDegree + data.degree >= limitDegree;
+      const arcRadius = isInFocus ? radius * 1.1 : radius;
+
+      if (isLimited) {
+        ctx?.arc(centerX, centerY, arcRadius, toRadian(currentDegree), toRadian(limitDegree), false);
+      } else {
+        ctx?.arc(centerX, centerY, arcRadius, toRadian(currentDegree), toRadian(currentDegree + data.degree), false);
+      }
+      currentDegree += data.degree;
+
+      ctx.closePath();
+      ctx.fillStyle = data.color;
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineJoin = 'round';
+      ctx.lineWidth = 0;
+      ctx.fill();
+      ctx.stroke();
+      ctx.restore();
+
+      if (isInFocus) {
+        const middleDegreeOfPie = currentDegree - (data.degree / 2);
+        const x = Math.cos(toRadian(middleDegreeOfPie)) * radius;
+        let y = Math.sqrt(Math.pow(radius, 2) - Math.pow(x, 2));
+        if (middleDegreeOfPie < 180) {
+          y *= -1;
+        }
+
+        const measureTextWidth = ctx.measureText(data.name).width > ctx.measureText(data.value.toString()).width ? ctx.measureText(data.name).width : ctx.measureText(data.value.toString()).width;
+
+        const PADDING_VALUE = 50;
+        const TEXT_PADDING_VALUE = PADDING_VALUE + 5;
+
+        const lineIncreaseX = x === 0 ? 0 : x < 0 ? -PADDING_VALUE : PADDING_VALUE;
+        const lineIncreaseY = y === 0 ? 0 : y < 0 ? PADDING_VALUE : -PADDING_VALUE;
+        const textIncreaseX = x === 0 ? 0 : x < 0 ? -(TEXT_PADDING_VALUE + measureTextWidth) : (TEXT_PADDING_VALUE);
+        const textIncreaseY = y === 0 ? 0 : y < 0 ? TEXT_PADDING_VALUE : -TEXT_PADDING_VALUE;
+
+        ctx.beginPath();
+        ctx.font = TITLE_FONT;
+        ctx.moveTo(centerX + x, centerY - y);
+        ctx.lineTo(centerX + x + lineIncreaseX, centerY - y + lineIncreaseY);
+        ctx.strokeStyle = data.color;
+        ctx.stroke();
+        ctx.fillText(data.name, centerX + x + textIncreaseX, centerY - y + textIncreaseY);
+        ctx.font = SUB_TITLE_FONT;
+        ctx.fillText(data.label, centerX + x + textIncreaseX, centerY - y + textIncreaseY + 15);
+        ctx.closePath();
+      }
+      if (isLimited) {
+        return;
+      }
+    }
+  }
+
+  private onMouseMove (e: MouseEvent): void {
+    const { ctx, centerX, centerY, width, height, radius } = this;
+    const absMousePos = this.getMousePos(e);
+
+    const x = absMousePos.x - centerX;
+    const y = -(absMousePos.y - centerY);
+
+    ctx?.clearRect(0, 0, width, height);
+    if (Math.abs(x) > radius || Math.abs(y) > radius) {
+      this.draw(360);
+      return;
+    }
+
+    const degree = calcDegreeWithLines(x, y);
+    this.draw(360, degree);
+  }
+
+  private getMousePos (e: MouseEvent) {
+    if (this.$canvas === undefined) {
+      return {
+        x: 0,
+        y: 0
+      };
+    }
+
+    const rect = this.$canvas.getBoundingClientRect();
+    return {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top
+    };
+  }
+}
+
+export default PieChartUIElement;

--- a/frontend/src/ui-elements/chart/pie-chart/index.ts
+++ b/frontend/src/ui-elements/chart/pie-chart/index.ts
@@ -134,7 +134,7 @@ class PieChartUIElement extends UIElement {
 
         const measureTextWidth = ctx.measureText(data.name).width > ctx.measureText(data.value.toString()).width ? ctx.measureText(data.name).width : ctx.measureText(data.value.toString()).width;
 
-        const PADDING_VALUE = 50;
+        const PADDING_VALUE = 30;
         const TEXT_PADDING_VALUE = PADDING_VALUE + 5;
 
         const lineIncreaseX = x === 0 ? 0 : x < 0 ? -PADDING_VALUE : PADDING_VALUE;
@@ -149,6 +149,7 @@ class PieChartUIElement extends UIElement {
         ctx.strokeStyle = data.color;
         ctx.stroke();
         ctx.fillText(data.name, centerX + x + textIncreaseX, centerY - y + textIncreaseY);
+
         ctx.font = SUB_TITLE_FONT;
         ctx.fillText(data.label, centerX + x + textIncreaseX, centerY - y + textIncreaseY + 15);
         ctx.closePath();

--- a/frontend/src/ui-elements/chart/pie-chart/index.ts
+++ b/frontend/src/ui-elements/chart/pie-chart/index.ts
@@ -67,6 +67,23 @@ class PieChartUIElement extends UIElement {
     this.drawWithAnimation(0);
   }
 
+  emphasize (index: number): void {
+    this.ctx?.clearRect(0, 0, this.width, this.height);
+    let currentDegree = 0;
+    for (let i = 0; i < index; i += 1) {
+      currentDegree += this.chartData[i].degree;
+    }
+
+    const focusDegree = (currentDegree + (currentDegree + this.chartData[index].degree)) / 2;
+
+    this.draw(360, focusDegree);
+  }
+
+  cancelEmphasize (): void {
+    this.ctx?.clearRect(0, 0, this.width, this.height);
+    this.draw(360);
+  }
+
   private formatChartData (data: PieChartInputData[]) {
     const total = data.reduce((sum, curr) => sum + curr.value, 0);
 

--- a/frontend/src/ui-elements/expenditure/expenditure-list/index.css
+++ b/frontend/src/ui-elements/expenditure/expenditure-list/index.css
@@ -1,0 +1,49 @@
+.expenditure--list {
+  --statistic-font-size: 18px
+}
+
+.expenditure-list__title {
+  color: var(--title-active);
+  font-weight: bold;
+  font-size: var(--body-large);
+  text-align: center;
+}
+
+.expenditure-list-wrapper {
+  width: 100%;
+  margin-top: 40px;
+}
+
+.expenditure-item {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+}
+
+.expenditure-item:hover {
+  background-color: var(--background);
+}
+
+.expenditure-item__category {
+  width: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--off-white);
+  height: 25px;
+  border-radius: 15px;
+  font-weight: bold;
+  font-size: var(--bold-medium);
+}
+
+.expenditure-item__statistic {
+  margin-left: 10px;
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--title-active);
+  font-size: var(--statistic-font-size);
+}

--- a/frontend/src/ui-elements/expenditure/expenditure-list/index.css
+++ b/frontend/src/ui-elements/expenditure/expenditure-list/index.css
@@ -22,6 +22,10 @@
   cursor: pointer;
 }
 
+.expenditure-item > * {
+  pointer-events: none;
+}
+
 .expenditure-item:hover {
   background-color: var(--background);
 }

--- a/frontend/src/ui-elements/expenditure/expenditure-list/index.ts
+++ b/frontend/src/ui-elements/expenditure/expenditure-list/index.ts
@@ -1,5 +1,6 @@
 import UIElement from '../../../core/ui-element';
 import { formatNumber } from '../../../utils/formatter';
+import { $ } from '../../../utils/selector';
 import { ExpenditureGroupedByCategory } from '../../../view-models/expenditure-in-month';
 
 import './index.css';
@@ -9,12 +10,16 @@ class ExpenditureListUIElement extends UIElement {
   private totalExpenditure: number;
   private year: number;
   private month: number;
+  private onCategoryMouseEnter: EventListener;
+  private onCategoryMouseLeave: EventListener;
 
   constructor ($target: HTMLElement,
     expenditureGroupedByCategory: ExpenditureGroupedByCategory[],
     totalExpenditure: number,
     year: number,
-    month: number) {
+    month: number,
+    onCategoryMouseEnter: EventListener,
+    onCategoryMouseLeave: EventListener) {
     super($target, {
       className: 'expenditure-list'
     });
@@ -23,6 +28,8 @@ class ExpenditureListUIElement extends UIElement {
     this.totalExpenditure = totalExpenditure;
     this.year = year;
     this.month = month;
+    this.onCategoryMouseEnter = onCategoryMouseEnter;
+    this.onCategoryMouseLeave = onCategoryMouseLeave;
   }
 
   protected render (): void {
@@ -34,9 +41,9 @@ class ExpenditureListUIElement extends UIElement {
 
       
       <div class="expenditure-list-wrapper">
-        ${expenditureGroupedByCategory.map(({ category, rate, expenditure }) => {
+        ${expenditureGroupedByCategory.map(({ index, category, rate, expenditure }) => {
           return `
-            <div class="expenditure-item">
+            <div class="expenditure-item" data-index=${index}>
               <div class="expenditure-item__category" style="background-color: ${category.color}">
                 ${category.name}
               </div>
@@ -51,7 +58,8 @@ class ExpenditureListUIElement extends UIElement {
   }
 
   protected addListener (): void {
-    // no events
+    $('.expenditure-list-wrapper')?.addEventListener('mousemove', this.onCategoryMouseEnter);
+    $('.expenditure-list-wrapper')?.addEventListener('mouseleave', this.onCategoryMouseLeave);
   }
 
   protected mount (): void {

--- a/frontend/src/ui-elements/expenditure/expenditure-list/index.ts
+++ b/frontend/src/ui-elements/expenditure/expenditure-list/index.ts
@@ -1,0 +1,62 @@
+import UIElement from '../../../core/ui-element';
+import { formatNumber } from '../../../utils/formatter';
+import { ExpenditureGroupedByCategory } from '../../../view-models/expenditure-in-month';
+
+import './index.css';
+
+class ExpenditureListUIElement extends UIElement {
+  private expenditureGroupedByCategory: ExpenditureGroupedByCategory[];
+  private totalExpenditure: number;
+  private year: number;
+  private month: number;
+
+  constructor ($target: HTMLElement,
+    expenditureGroupedByCategory: ExpenditureGroupedByCategory[],
+    totalExpenditure: number,
+    year: number,
+    month: number) {
+    super($target, {
+      className: 'expenditure-list'
+    });
+
+    this.expenditureGroupedByCategory = expenditureGroupedByCategory;
+    this.totalExpenditure = totalExpenditure;
+    this.year = year;
+    this.month = month;
+  }
+
+  protected render (): void {
+    const { expenditureGroupedByCategory, totalExpenditure, year, month } = this;
+    this.$element.innerHTML = `
+      <div class="expenditure-list__title">
+        ${year}년 ${month}월, ${formatNumber(totalExpenditure)}
+      </div>
+
+      
+      <div class="expenditure-list-wrapper">
+        ${expenditureGroupedByCategory.map(({ category, rate, expenditure }) => {
+          return `
+            <div class="expenditure-item">
+              <div class="expenditure-item__category" style="background-color: ${category.color}">
+                ${category.name}
+              </div>
+
+              <div class="expenditure-item__statistic">
+                <span>${Math.round(rate)}%</span>
+                <span>${formatNumber(expenditure)}</span>
+              </div>
+            </div>`;
+        }).join('')}
+    `;
+  }
+
+  protected addListener (): void {
+    // no events
+  }
+
+  protected mount (): void {
+    // no mount
+  }
+}
+
+export default ExpenditureListUIElement;

--- a/frontend/src/utils/math.ts
+++ b/frontend/src/utils/math.ts
@@ -1,0 +1,18 @@
+export const toRadian = (degree: number): number => {
+  return Math.PI / 180 * degree;
+};
+
+export const toDegree = (radian: number): number => {
+  return radian * (180 / Math.PI);
+};
+
+export const calcDegreeWithLines = (width: number, height: number): number => {
+  const z = Math.sqrt(Math.pow(width, 2) + Math.pow(height, 2));
+
+  const degree = toDegree(Math.acos(width / z));
+  if (height > 0) {
+    return 360 - degree;
+  }
+
+  return degree;
+};

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,7 @@
+export const sleep = (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+};

--- a/frontend/src/view-models/expenditure-in-month.ts
+++ b/frontend/src/view-models/expenditure-in-month.ts
@@ -14,7 +14,7 @@ import { Category } from '../types/category';
 import { PieChartInputData } from '../ui-elements/chart/pie-chart';
 import { formatNumber } from '../utils/formatter';
 
-type ExpenditureGroupedByCategory = {
+export type ExpenditureGroupedByCategory = {
   expenditure: number;
   rate: number;
   category: Category;
@@ -61,6 +61,18 @@ class ExpenditureInMonthViewModel extends ViewModel {
     pubsub.subscribe(actions.ON_CATEGORIES_CHANGE, () => {
       this.view.build();
     });
+  }
+
+  get focusedMonth (): number {
+    return this.focusDateModel.focusDate.getMonth() + 1;
+  }
+
+  get focusedYear (): number {
+    return this.focusDateModel.focusDate.getFullYear();
+  }
+
+  get totalExpenditure (): number {
+    return this.cashHistoriesModel.cashHistories?.cashHistories.totalExpenditure ?? 0;
   }
 
   get expenditurePieChartInput (): PieChartInputData[] {

--- a/frontend/src/view-models/expenditure-in-month.ts
+++ b/frontend/src/view-models/expenditure-in-month.ts
@@ -1,0 +1,101 @@
+import cashHistoryAPI from '../api/cash-history';
+import categoryAPI from '../api/category';
+import actions from '../constant/actions';
+import pubsub from '../core/pubsub';
+import View from '../core/view';
+import ViewModel from '../core/view-model';
+import { CashHistories } from '../enums/cash-history.enum';
+import models from '../models';
+import { CashHistoriesData } from '../models/cash-histories';
+import { CategoriesData } from '../models/categories';
+import { FocusDateData } from '../models/focus-date';
+import { CashHistory } from '../types/cash-history';
+import { Category } from '../types/category';
+
+type ExpenditureGroupedByCategory = {
+  expenditure: number;
+  rate: number;
+  category: Category;
+}
+
+class ExpenditureInMonthViewModel extends ViewModel {
+  private cashHistoriesModel: CashHistoriesData;
+  private focusDateModel: FocusDateData;
+  private categoriesModel: CategoriesData;
+
+  constructor (view: View) {
+    super(view);
+    this.cashHistoriesModel = models.cashHistories;
+    this.focusDateModel = models.focusDate;
+    this.categoriesModel = models.categories;
+
+    this.fetchCashHistories();
+    this.fetchCategories();
+  }
+
+  private async fetchCategories () {
+    const categories = await categoryAPI.fetchCategories();
+    this.categoriesModel.categories = categories;
+  }
+
+  private async fetchCashHistories () {
+    const { focusDate } = this.focusDateModel;
+    const year = focusDate.getFullYear();
+    const month = focusDate.getMonth() + 1;
+
+    const cashHistories = await cashHistoryAPI.fetchCashHistories(year, month);
+    this.cashHistoriesModel.cashHistories = cashHistories;
+  }
+
+  protected subscribe (): void {
+    pubsub.subscribe(actions.ON_FOCUS_DATE_CHANGE, () => {
+      this.fetchCashHistories();
+    });
+
+    pubsub.subscribe(actions.ON_CASH_HISTORY_CHANGE, () => {
+      this.view.build();
+    });
+
+    pubsub.subscribe(actions.ON_CATEGORIES_CHANGE, () => {
+      this.view.build();
+    });
+  }
+
+  get expenditureGroupedByCategory (): ExpenditureGroupedByCategory[] {
+    if (this.categoriesModel.categories === null ||
+      this.cashHistoriesModel.cashHistories === null) {
+      return [];
+    }
+
+    const { cashHistories } = this.cashHistoriesModel.cashHistories;
+    const categories = this.categoriesModel.categories.categories.filter((category) => {
+      return category.type === CashHistories.Expenditure;
+    });
+
+    const { totalExpenditure, groupedCashHistories } = cashHistories;
+    const totalCashHistories = groupedCashHistories.reduce((totalCashHistories, dailyCashHistory) => {
+      return [
+        ...totalCashHistories,
+        ...dailyCashHistory.cashHistories
+      ];
+    }, [] as CashHistory[]);
+
+    const cashHistoriesGroupedByCategory = categories.map((category) => {
+      const expenditure = totalCashHistories
+        .filter((cashHistory) => cashHistory.categoryId === category.id)
+        .reduce((sum, cashHistory) => sum + cashHistory.price, 0);
+
+      return {
+        category,
+        expenditure,
+        rate: expenditure / totalExpenditure * 100
+      };
+    });
+
+    cashHistoriesGroupedByCategory.sort((a, b) => b.expenditure - a.expenditure);
+
+    return cashHistoriesGroupedByCategory;
+  }
+}
+
+export default ExpenditureInMonthViewModel;

--- a/frontend/src/view-models/expenditure-in-month.ts
+++ b/frontend/src/view-models/expenditure-in-month.ts
@@ -15,6 +15,7 @@ import { PieChartInputData } from '../ui-elements/chart/pie-chart';
 import { formatNumber } from '../utils/formatter';
 
 export type ExpenditureGroupedByCategory = {
+  index: number;
   expenditure: number;
   rate: number;
   category: Category;
@@ -82,9 +83,10 @@ class ExpenditureInMonthViewModel extends ViewModel {
     }
 
     return this.expenditureGroupedByCategory.map((categoryExpenditure) => {
-      const { category, expenditure } = categoryExpenditure;
+      const { index, category, expenditure } = categoryExpenditure;
 
       return {
+        kye: index,
         name: category.name,
         color: category.color,
         value: expenditure,
@@ -112,12 +114,13 @@ class ExpenditureInMonthViewModel extends ViewModel {
       ];
     }, [] as CashHistory[]);
 
-    const cashHistoriesGroupedByCategory = categories.map((category) => {
+    const cashHistoriesGroupedByCategory = categories.map((category, index) => {
       const expenditure = totalCashHistories
         .filter((cashHistory) => cashHistory.categoryId === category.id)
         .reduce((sum, cashHistory) => sum + cashHistory.price, 0);
 
       return {
+        index,
         category,
         expenditure,
         rate: expenditure / totalExpenditure * 100

--- a/frontend/src/view-models/expenditure-in-month.ts
+++ b/frontend/src/view-models/expenditure-in-month.ts
@@ -11,6 +11,8 @@ import { CategoriesData } from '../models/categories';
 import { FocusDateData } from '../models/focus-date';
 import { CashHistory } from '../types/cash-history';
 import { Category } from '../types/category';
+import { PieChartInputData } from '../ui-elements/chart/pie-chart';
+import { formatNumber } from '../utils/formatter';
 
 type ExpenditureGroupedByCategory = {
   expenditure: number;
@@ -58,6 +60,24 @@ class ExpenditureInMonthViewModel extends ViewModel {
 
     pubsub.subscribe(actions.ON_CATEGORIES_CHANGE, () => {
       this.view.build();
+    });
+  }
+
+  get expenditurePieChartInput (): PieChartInputData[] {
+    const totalExpenditure = this.cashHistoriesModel.cashHistories?.cashHistories.totalExpenditure ?? 0;
+    if (totalExpenditure <= 0) {
+      return [];
+    }
+
+    return this.expenditureGroupedByCategory.map((categoryExpenditure) => {
+      const { category, expenditure } = categoryExpenditure;
+
+      return {
+        name: category.name,
+        color: category.color,
+        value: expenditure,
+        label: formatNumber(expenditure)
+      };
     });
   }
 

--- a/frontend/src/views/expenditure-in-month/index.css
+++ b/frontend/src/views/expenditure-in-month/index.css
@@ -1,3 +1,15 @@
+.pie-chart-view--no-data {
+  width: 100%;
+  height: 425px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.grouped-expenditure--no-data {
+  width: 100%;
+}
+
 .expenditure-in-month {
   padding: 30px;
   display: flex;

--- a/frontend/src/views/expenditure-in-month/index.css
+++ b/frontend/src/views/expenditure-in-month/index.css
@@ -1,2 +1,15 @@
-.pie-chart-view {
+.expenditure-in-month {
+  padding: 30px;
+  display: flex;
+  width: var(--inner-width);
+  position: relative;
+  top: -20px;
+  background-color: var(--off-white);
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  margin: 0 auto;
+}
+
+.grouped-expenditure {
+  width: 100%;
 }

--- a/frontend/src/views/expenditure-in-month/index.css
+++ b/frontend/src/views/expenditure-in-month/index.css
@@ -1,0 +1,2 @@
+.pie-chart-view {
+}

--- a/frontend/src/views/expenditure-in-month/index.ts
+++ b/frontend/src/views/expenditure-in-month/index.ts
@@ -1,0 +1,38 @@
+import View from '../../core/view';
+import PieChartUIElement from '../../ui-elements/chart/pie-chart';
+import { $ } from '../../utils/selector';
+import ExpenditureInMonthViewModel from '../../view-models/expenditure-in-month';
+
+import './index.css';
+
+class ExpenditureInMonthView extends View {
+  private expenditureInMonthViewModel: ExpenditureInMonthViewModel;
+
+  constructor ($target: HTMLElement) {
+    super($target);
+    this.expenditureInMonthViewModel = new ExpenditureInMonthViewModel(this);
+  }
+
+  protected addListener (): void {
+    // no event
+  }
+
+  protected render (): void {
+    const { expenditurePieChartInput } = this.expenditureInMonthViewModel;
+    this.$target.innerHTML = `
+      ${expenditurePieChartInput.length <= 0
+        ? '<div class="pie-chart-view--no-data">데이터가 없습니다</div>'
+        : '<div class="pie-chart-view"></div>'
+      }
+    `;
+  }
+
+  protected mount (): void {
+    const $pieChartView = $('.pie-chart-view');
+    if ($pieChartView !== null) {
+      new PieChartUIElement(this.$target, this.expenditureInMonthViewModel.expenditurePieChartInput, 600, 600).build();
+    }
+  }
+}
+
+export default ExpenditureInMonthView;

--- a/frontend/src/views/expenditure-in-month/index.ts
+++ b/frontend/src/views/expenditure-in-month/index.ts
@@ -1,5 +1,6 @@
 import View from '../../core/view';
 import PieChartUIElement from '../../ui-elements/chart/pie-chart';
+import ExpenditureListUIElement from '../../ui-elements/expenditure/expenditure-list';
 import { $ } from '../../utils/selector';
 import ExpenditureInMonthViewModel from '../../view-models/expenditure-in-month';
 
@@ -20,17 +21,32 @@ class ExpenditureInMonthView extends View {
   protected render (): void {
     const { expenditurePieChartInput } = this.expenditureInMonthViewModel;
     this.$target.innerHTML = `
-      ${expenditurePieChartInput.length <= 0
-        ? '<div class="pie-chart-view--no-data">데이터가 없습니다</div>'
-        : '<div class="pie-chart-view"></div>'
-      }
+      <div class="expenditure-in-month">
+        ${expenditurePieChartInput.length <= 0
+          ? '<div class="pie-chart-view--no-data">데이터가 없습니다</div>'
+          : '<div class="pie-chart-view"></div>'
+        }
+
+        <div class="grouped-expenditure">
+        </div>
+      </div>
     `;
   }
 
   protected mount (): void {
     const $pieChartView = $('.pie-chart-view');
     if ($pieChartView !== null) {
-      new PieChartUIElement(this.$target, this.expenditureInMonthViewModel.expenditurePieChartInput, 600, 600).build();
+      new PieChartUIElement($pieChartView, this.expenditureInMonthViewModel.expenditurePieChartInput, 420, 420).build();
+    }
+
+    const $groupedExpenditure = $('.grouped-expenditure');
+    if ($groupedExpenditure !== null) {
+      new ExpenditureListUIElement($groupedExpenditure,
+        this.expenditureInMonthViewModel.expenditureGroupedByCategory,
+        this.expenditureInMonthViewModel.totalExpenditure,
+        this.expenditureInMonthViewModel.focusedYear,
+        this.expenditureInMonthViewModel.focusedMonth
+      ).build();
     }
   }
 }

--- a/frontend/src/views/expenditure-in-month/index.ts
+++ b/frontend/src/views/expenditure-in-month/index.ts
@@ -8,10 +8,25 @@ import './index.css';
 
 class ExpenditureInMonthView extends View {
   private expenditureInMonthViewModel: ExpenditureInMonthViewModel;
+  private pieChartUIElement?: PieChartUIElement;
 
   constructor ($target: HTMLElement) {
     super($target);
     this.expenditureInMonthViewModel = new ExpenditureInMonthViewModel(this);
+  }
+
+  private onCategoryMouseEnter = (e: Event) => {
+    const target = e.target as HTMLElement;
+    const { index } = target.dataset;
+    if (index === undefined) {
+      return;
+    }
+
+    this.pieChartUIElement?.emphasize(Number(index));
+  }
+
+  private onCategoryMouseLeave = () => {
+    this.pieChartUIElement?.cancelEmphasize();
   }
 
   protected addListener (): void {
@@ -35,7 +50,8 @@ class ExpenditureInMonthView extends View {
   protected mount (): void {
     const $pieChartView = $('.pie-chart-view');
     if ($pieChartView !== null) {
-      new PieChartUIElement($pieChartView, this.expenditureInMonthViewModel.expenditurePieChartInput, 420, 420).build();
+      this.pieChartUIElement = new PieChartUIElement($pieChartView, this.expenditureInMonthViewModel.expenditurePieChartInput, 420, 420);
+      this.pieChartUIElement.build();
     }
 
     const $groupedExpenditure = $('.grouped-expenditure');
@@ -44,7 +60,9 @@ class ExpenditureInMonthView extends View {
         this.expenditureInMonthViewModel.expenditureGroupedByCategory,
         this.expenditureInMonthViewModel.totalExpenditure,
         this.expenditureInMonthViewModel.focusedYear,
-        this.expenditureInMonthViewModel.focusedMonth
+        this.expenditureInMonthViewModel.focusedMonth,
+        this.onCategoryMouseEnter,
+        this.onCategoryMouseLeave
       ).build();
     }
   }

--- a/frontend/src/views/expenditure-in-month/index.ts
+++ b/frontend/src/views/expenditure-in-month/index.ts
@@ -24,10 +24,9 @@ class ExpenditureInMonthView extends View {
       <div class="expenditure-in-month">
         ${expenditurePieChartInput.length <= 0
           ? '<div class="pie-chart-view--no-data">데이터가 없습니다</div>'
-          : '<div class="pie-chart-view"></div>'
+          : `<div class="pie-chart-view"></div>
+            <div class="grouped-expenditure">`
         }
-
-        <div class="grouped-expenditure">
         </div>
       </div>
     `;


### PR DESCRIPTION
## :bookmark_tabs: #83 현재 focus된 달의 지출 시각화 View

현재 날짜의 지출 내역을 pie chart로 보여주며 카테고리 리스트를 뿌려줌


## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?

- [x] Coding Convention을 준수했나요?

- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 4시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* PieChart가 애니메이션으로 나오며 마우스 호버 시 강조
* 카테고리 리스트가 나오며 마우스 호버 시 차트 강조



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점



- 차트가 확실히 너무 장황하네요.. 수정을 하고 싶은데 시간 되면 리펙토링을 진행해보겠습니다 ! 이번 리뷰에서 짚어주셔도 되요 :)
- 카테고리 리스트에서 마우스 호버 시 이벤트는 View에서 내려줍니다. 해당 이벤트 핸들리와 비슷하게 클릭 이벤트 핸들러도 만들면 될 것 같아요 ㅎㅎ



![스크린샷 2021-08-04 오전 11 11 18](https://user-images.githubusercontent.com/49791336/128110765-fe5717ed-27bb-40c3-b0ec-104d4274924b.png)

https://user-images.githubusercontent.com/49791336/128110767-4ed2ee69-b265-4b68-b8eb-64e2646fc0ed.mov



