### PR TITLE
[fix/cash history list update bug] 가계 내역 업데이트 이슈 및 역순 정렬

### DIFF
--- a/frontend/src/view-models/console.ts
+++ b/frontend/src/view-models/console.ts
@@ -34,7 +34,7 @@ class ConsoleViewModel extends ViewModel {
   private categoriesModel: CategoriesData;
   private paymentsModel: PaymentsData;
   private focusDateModel: FocusDateData;
-  private filteredCashHistoriesModel: CashHistoriesData;
+  private cashHistoriesModel: CashHistoriesData;
   private _cashHistoryType: CashHistories = CashHistories.Income;
 
   constructor (view: View) {
@@ -43,7 +43,7 @@ class ConsoleViewModel extends ViewModel {
     this.categoriesModel = models.categories;
     this.paymentsModel = models.payments;
     this.focusDateModel = models.focusDate;
-    this.filteredCashHistoriesModel = models.filteredCashHistories;
+    this.cashHistoriesModel = models.cashHistories;
 
     this.initCashHistory();
     this.fetchCategories();
@@ -88,7 +88,7 @@ class ConsoleViewModel extends ViewModel {
     const date = this.focusDateModel.focusDate;
     try {
       const histories = await cashHistoryAPI.fetchCashHistories(date.getFullYear(), date.getMonth() + 1);
-      this.filteredCashHistoriesModel.cashHistories = histories;
+      this.cashHistoriesModel.cashHistories = histories;
     } catch (error) {
       const { status } = error;
 

--- a/frontend/src/view-models/main.ts
+++ b/frontend/src/view-models/main.ts
@@ -16,7 +16,7 @@ class MainViewModel extends ViewModel {
   private cashHistoriesModel: CashHistoriesData;
   private filteredCashHistoriesModel: CashHistoriesData;
   private cashHistoryModel: CashHistoryData;
-  private filterType: CashHistories | null;
+  private selectedFilter: CashHistories[] = [CashHistories.Income, CashHistories.Expenditure];
 
   constructor (view: View) {
     super(view);
@@ -24,30 +24,31 @@ class MainViewModel extends ViewModel {
     this.cashHistoriesModel = models.cashHistories;
     this.filteredCashHistoriesModel = models.filteredCashHistories;
     this.cashHistoryModel = models.cashHistory;
-    this.filterType = null;
     this.fetchCashHistories();
   }
 
   protected subscribe (): void {
-    pubsub.subscribe(actions.ON_FOCUS_DATE_CHANGE, async () => {
-      await this.fetchCashHistories();
-
-      if (this.filterType === null) {
-        return;
-      }
-      this.filterData(this.filterType);
+    pubsub.subscribe(actions.ON_FOCUS_DATE_CHANGE, () => {
+      this.fetchCashHistories()
+        .then(() => {
+          this.applyFilter();
+        });
     });
 
     pubsub.subscribe(actions.ON_CASH_HISTORIES_CHANGE, () => {
-      this.view.build();
+      this.applyFilter();
     });
 
     pubsub.subscribe(actions.ON_FILTERED_CASH_HISTORIES_CHANGE, () => {
       this.view.build();
     });
 
-    pubsub.subscribe(actions.ON_CASH_HISTORY_CHANGE, () => {
-      this.view.build();
+    pubsub.subscribe(actions.ON_CATEGORIES_CHANGE, () => {
+      this.fetchCashHistories();
+    });
+
+    pubsub.subscribe(actions.ON_PAYMENTS_CHANGE, () => {
+      this.fetchCashHistories();
     });
   }
 
@@ -67,7 +68,7 @@ class MainViewModel extends ViewModel {
     }
   }
 
-  filterData (type: number): void {
+  applyFilter (): void {
     const { cashHistories } = this.cashHistoriesModel;
     if (cashHistories === null) {
       return;
@@ -75,7 +76,7 @@ class MainViewModel extends ViewModel {
 
     const filtered = cashHistories.cashHistories.groupedCashHistories.map((monthlyCashHistory) => ({
       ...monthlyCashHistory,
-      cashHistories: monthlyCashHistory.cashHistories.filter(e => e.type === type)
+      cashHistories: monthlyCashHistory.cashHistories.filter(e => this.selectedFilter.includes(e.type))
     }));
 
     this.filteredCashHistoriesModel.cashHistories = {
@@ -88,27 +89,17 @@ class MainViewModel extends ViewModel {
   }
 
   filterButtonClick (isIncomeChecked: boolean, isExpenditureChecked: boolean): void {
-    if (isIncomeChecked && isExpenditureChecked) {
-      this.filteredCashHistoriesModel.cashHistories = this.cashHistoriesModel.cashHistories;
-    } else if (isIncomeChecked) {
-      this.filterType = CashHistories.Income;
-      this.filterData(this.filterType);
-    } else if (isExpenditureChecked) {
-      this.filterType = CashHistories.Expenditure;
-      this.filterData(this.filterType);
-    } else {
-      if (this.filteredCashHistoriesModel.cashHistories === null) {
-        return;
-      }
-      this.filteredCashHistoriesModel.cashHistories = {
-        ...this.filteredCashHistoriesModel.cashHistories,
-        cashHistories: {
-          totalIncome: 0,
-          totalExpenditure: 0,
-          groupedCashHistories: []
-        }
-      };
+    this.selectedFilter = [];
+
+    if (isIncomeChecked) {
+      this.selectedFilter.push(CashHistories.Income);
     }
+
+    if (isExpenditureChecked) {
+      this.selectedFilter.push(CashHistories.Expenditure);
+    }
+
+    this.applyFilter();
   }
 
   onCashHistoryClick (e:Event): void {

--- a/frontend/src/view-models/main.ts
+++ b/frontend/src/view-models/main.ts
@@ -57,8 +57,8 @@ class MainViewModel extends ViewModel {
 
     try {
       const histories = await cashHistoryAPI.fetchCashHistories(date.getFullYear(), date.getMonth() + 1);
+      histories.cashHistories.groupedCashHistories.reverse();
       this.cashHistoriesModel.cashHistories = histories;
-      this.filteredCashHistoriesModel.cashHistories = histories;
     } catch (error) {
       const { status } = error;
 


### PR DESCRIPTION
## :bookmark_tabs: #110 #106 가계 내역 업데이트 이슈 및 역순 정렬

가계내역의 필터 시 외부 요인에 의한 업데이트에 따라 오류가 발생하는 부분을 수정
가계 내역을 역순으로 정렬

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 가계 내역 필터링 로직 리펙토링
* 가계 내역 필터링 구독 부분 수정
* 가계 내역 혹은 카테고리/결제수단이 변경됐을경우 필터링 부분도 랜더링
* 가계 내역 역순 정렬



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

