### PR TITLE
[fix/cash history create update reverse bug] 가계 내역 생성 시 역순 정렬 유지

### DIFF
--- a/frontend/src/view-models/main.ts
+++ b/frontend/src/view-models/main.ts
@@ -57,7 +57,6 @@ class MainViewModel extends ViewModel {
 
     try {
       const histories = await cashHistoryAPI.fetchCashHistories(date.getFullYear(), date.getMonth() + 1);
-      histories.cashHistories.groupedCashHistories.reverse();
       this.cashHistoriesModel.cashHistories = histories;
     } catch (error) {
       const { status } = error;
@@ -77,7 +76,7 @@ class MainViewModel extends ViewModel {
     const filtered = cashHistories.cashHistories.groupedCashHistories.map((monthlyCashHistory) => ({
       ...monthlyCashHistory,
       cashHistories: monthlyCashHistory.cashHistories.filter(e => this.selectedFilter.includes(e.type))
-    }));
+    })).reverse();
 
     this.filteredCashHistoriesModel.cashHistories = {
       ...cashHistories,


### PR DESCRIPTION
## :bookmark_tabs: #132 가계 내역 생성 시 역순 정렬 유지



## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [ ] Warning Message가 발생하지 않았나요?
- [ ] Coding Convention을 준수했나요?
- [ ] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 기존 메인 view에서 fetch 시 역순 정렬한 부분을 filter 시 정렬하도록 변경



## :construction: PR 특이 사항

