### PR TITLE
[feature/cash history item conditional price] 한달 가계 내역 아이템 수입 지출이 있을 경우만 표시

### DIFF
--- a/frontend/src/ui-elements/cash-history/monthly-cash-history/index.ts
+++ b/frontend/src/ui-elements/cash-history/monthly-cash-history/index.ts
@@ -40,12 +40,14 @@ class MonthlyCashHistoryUIElement extends UIElement {
         return;
       }
       const $date = document.createElement('div');
+      const { date, day, income, expenditure } = cashHistoriesInDay;
+
       $date.innerHTML = `
         <div class="monthly-cash-history__header">
-          <div class="">${cashHistoriesInDay.month}월 ${cashHistoriesInDay.date}일</div>
-          <div class="monthly-cash-history__day">${getDayString(cashHistoriesInDay.day)}</div>
-          <div class="monthly-cash-history__income">수입 ${formatNumber(cashHistoriesInDay.income)}</div>
-          <div class="monthly-cash-history__expenditure">지출 ${formatNumber(cashHistoriesInDay.expenditure)}</div>
+          <div class="">${cashHistoriesInDay.month}월 ${date}일</div>
+          <div class="monthly-cash-history__day">${getDayString(day)}</div>
+          ${income > 0 ? `<div class="monthly-cash-history__income">수입 ${formatNumber(income)}</div>` : ''}
+          ${expenditure > 0 ? `<div class="monthly-cash-history__expenditure">지출 ${formatNumber(expenditure)}</div>` : ''}
         </div>
       `;
       $container.appendChild($date);


### PR DESCRIPTION
## :bookmark_tabs: #114  한달 가계 내역 아이템 수입 지출이 있을 경우만 표시

한달 가계 내역 아이템에서 수입, 지출이 없다면 띄우지 않음

## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [ ] Warning Message가 발생하지 않았나요?
- [ ] Coding Convention을 준수했나요?
- [ ] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 수입, 지출에 조건부 랜더링을 통해 해당 값이 있다면 랜더링



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

<참고 - 지출이 없는경우>
![image](https://user-images.githubusercontent.com/49791336/128348960-bb2f4e73-4fef-46de-ab3c-9451c262a0af.png)


