### PR TITLE
[fix/duplicate category payment bug] 중복 카테고리, 결제수단 오류 수정

### DIFF
--- a/backend/src/repositories/category.repository.ts
+++ b/backend/src/repositories/category.repository.ts
@@ -9,11 +9,10 @@ class CategoryRepository extends Repository<Category> {
       .getMany();
   }
 
-  findByName (name: string): Promise<Category | undefined> {
+  findByUserAndName (userId: number, name: string): Promise<Category | undefined> {
     return createQueryBuilder(Category)
-      .where({
-        name
-      })
+      .where('user_id = :userId', { userId })
+      .andWhere('name = :name', { name })
       .getOne();
   }
 }

--- a/backend/src/repositories/payment.repository.ts
+++ b/backend/src/repositories/payment.repository.ts
@@ -9,11 +9,10 @@ class PaymentRepository extends Repository<Payment> {
       .getMany();
   }
 
-  findByName (name: string): Promise<Payment | undefined> {
+  findByUserAndName (userId: number, name: string): Promise<Payment | undefined> {
     return createQueryBuilder(Payment)
-      .where({
-        name
-      })
+      .where('user_id = :userId', { userId })
+      .andWhere('name = :name', { name })
       .getOne();
   }
 }

--- a/backend/src/services/category.service.ts
+++ b/backend/src/services/category.service.ts
@@ -21,7 +21,7 @@ class CategoryService {
       .user(user)
       .build();
 
-    const duplicatedCategory = await getCustomRepository(CategoryRepository).findByName(newCategory.name);
+    const duplicatedCategory = await getCustomRepository(CategoryRepository).findByUserAndName(user.id, newCategory.name);
     if (duplicatedCategory !== undefined) {
       throw new DuplicateCategoryError('해당 카테고리가 이미 존재합니다');
     }

--- a/backend/src/services/payment.service.ts
+++ b/backend/src/services/payment.service.ts
@@ -19,7 +19,7 @@ class PaymentService {
       .user(user)
       .build();
 
-    const duplicatedPayment = await getCustomRepository(PaymentRepository).findByName(newPayment.name);
+    const duplicatedPayment = await getCustomRepository(PaymentRepository).findByUserAndName(user.id, newPayment.name);
     if (duplicatedPayment !== undefined) {
       throw new DuplicatePaymentError('해당 결제수단이 이미 존재합니다');
     }


### PR DESCRIPTION
## :bookmark_tabs:  #155 중복 카테고리, 결제수단 오류 수정


## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.



- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] `npm run lint`나 `yarn lint`를 실행하였나요?


## 소요 시간
> 이슈를 해결하며 사용된 시간

- 0.5시간

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역



* 해당 회원이 아닌 카테고리, 결제수단에 중복확인 오류 수정



## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
